### PR TITLE
Fix 'assigned but unused variable' warning

### DIFF
--- a/lib/ae/core_ext/helpers.rb
+++ b/lib/ae/core_ext/helpers.rb
@@ -161,7 +161,7 @@ class Proc
   # TODO: wrong place, change yield?
   def change?
     pre_result = yield
-    called = call
+    call
     post_result = yield
     pre_result != post_result
   end


### PR DESCRIPTION
Ruby 2.5 shows the following warning:

    /usr/local/lib/ruby/gems/2.5.0/gems/ae-1.8.2/lib/ae/core_ext/helpers.rb:164: warning: assigned but unused variable - called
